### PR TITLE
unbundle yourkit profiler from docker build container to not violate …

### DIFF
--- a/carbonj.service/Dockerfile
+++ b/carbonj.service/Dockerfile
@@ -93,10 +93,6 @@ ENV DW_PREFIX=jetty
 ENV SERVICEDIR=/app/
 ENV app_servicedir=/app/
 
-RUN wget https://download.yourkit.com/yjp/2017.02/YourKit-JavaProfiler-2017.02-b75.zip -P /tmp/ && \
-  unzip /tmp/YourKit-JavaProfiler-2017.02-b75.zip && mv YourKit-JavaProfiler-2017.02 /usr/local/yjp/ && \
-  rm /tmp/YourKit-JavaProfiler-2017.02-b75.zip
-RUN wget https://download.yourkit.com/yjp/2017.02/yjp.jar -P /usr/local/yjp/lib/
 # Add Tini for proper sigkill handling https://github.com/krallin/tini
 RUN wget https://github.com/krallin/tini/releases/download/v0.18.0/tini
 RUN mv tini /sbin/tini

--- a/carbonj.service/src/main/docker/files/entrypoint.sh
+++ b/carbonj.service/src/main/docker/files/entrypoint.sh
@@ -54,6 +54,15 @@ for SVC_PROP in `compgen -A variable | grep "^SVC_PROP_"` ; do
 	printf '%s=%s\n' "$var_lowercase" "${!SVC_PROP}" >> $SERVICEDIR/config/overrides.properties
 done
 
+# download optional yourkit profiler at runtime
+if [ "$ENABLE_YOURKIT_PROFILER" == "true" ]
+then
+  wget https://download.yourkit.com/yjp/2017.02/YourKit-JavaProfiler-2017.02-b75.zip -P /tmp/ && \
+    unzip /tmp/YourKit-JavaProfiler-2017.02-b75.zip && mv YourKit-JavaProfiler-2017.02 /usr/local/yjp/ && \
+    rm /tmp/YourKit-JavaProfiler-2017.02-b75.zip
+  wget https://download.yourkit.com/yjp/2017.02/yjp.jar -P /usr/local/yjp/lib/
+fi
+
 #########################
 #########################
 #########################

--- a/carbonj.service/src/main/docker/files/entrypoint.sh
+++ b/carbonj.service/src/main/docker/files/entrypoint.sh
@@ -60,7 +60,8 @@ then
   wget https://download.yourkit.com/yjp/2017.02/YourKit-JavaProfiler-2017.02-b75.zip -P /tmp/ && \
     unzip /tmp/YourKit-JavaProfiler-2017.02-b75.zip && mv YourKit-JavaProfiler-2017.02 /usr/local/yjp/ && \
     rm /tmp/YourKit-JavaProfiler-2017.02-b75.zip
-  wget https://download.yourkit.com/yjp/2017.02/yjp.jar -P /usr/local/yjp/lib/
+  wget https://download.yourkit.com/yjp/2017.02/yjp.jar -P /tmp
+  mv /tmp/yjp.jar /usr/local/yjp/lib/yjp.jar
 fi
 
 #########################


### PR DESCRIPTION
…license terms, instead download at runtime as specified by user through ENABLE_YOURKIT_PROFILER=true command line option