### PR TITLE
Update pcp-conf and pcp-libs to 6.3.7-9.el9 to fix build

### DIFF
--- a/carbonj.service/Dockerfile
+++ b/carbonj.service/Dockerfile
@@ -18,8 +18,8 @@ RUN yum update -y && \
   yum install -y gcc-c++ gcc make libtool automake autoconf make python3-devel && \
   rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
   yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
-  yum install -y https://mirror.stream.centos.org/9-stream/AppStream/$(uname -m)/os/Packages/pcp-conf-6.3.4-1.el9.$(uname -m).rpm && \
-  yum install -y https://mirror.stream.centos.org/9-stream/AppStream/$(uname -m)/os/Packages/pcp-libs-6.3.4-1.el9.$(uname -m).rpm  && \
+  yum install -y https://mirror.stream.centos.org/9-stream/AppStream/$(uname -m)/os/Packages/pcp-conf-6.3.7-9.el9.$(uname -m).rpm && \
+  yum install -y https://mirror.stream.centos.org/9-stream/AppStream/$(uname -m)/os/Packages/pcp-libs-6.3.7-9.el9.$(uname -m).rpm  && \
   #
   # If sysstat version is updated, confirm iolog.sh execution and update associated version check in entrypoint.sh
   #


### PR DESCRIPTION
The previous version 6.3.4-1.el9 is no longer available in the CentOS Stream 9 AppStream mirror, causing the Docker build to fail.