### PR TITLE
Upgrade GitHub Actions workflows off Node 20 runners

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Setup Java JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'zulu'
@@ -55,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
        ./gradlew -PdockerRepo=salesforce/ -x test build  --info
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 17
@@ -28,9 +28,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         report_paths: '**/build/test-results/test/TEST-*.xml'
     - name: Extract project version
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-      run: echo "::set-env name=GRADLE_PROJECT_VERSION::`./gradlew properties|grep version |cut -c 10-`"
+      run: echo "GRADLE_PROJECT_VERSION=$(./gradlew properties | grep '^version:' | cut -c 10-)" >> "$GITHUB_ENV"
     - name: Show project version
       run: echo "$GRADLE_PROJECT_VERSION"
     - name: Publish Docker container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'zulu'


### PR DESCRIPTION
Bumps actions/checkout (v3->v5), actions/setup-java (v2->v4), and github/codeql-action (v1->v3) ahead of the Node 20 deprecation. Also replaces the deprecated `::set-env` workflow command with $GITHUB_ENV in gradle.yml so the unsafe-commands opt-in is no longer required.