### PR TITLE
ci: declare minimum permissions on CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '35 4 * * 3'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Adds an explicit top-level `permissions` block to `.github/workflows/codeql-analysis.yml` with the three scopes the analyze job actually uses: `actions: read` (to read the workflow run), `contents: read` (checkout), and `security-events: write` (uploading SARIF via `github/codeql-action/analyze`). This matches the canonical CodeQL template in GitHub's docs.

Today the workflow has no `permissions:` block at all, so the run inherits whatever the repo or org default `GITHUB_TOKEN` scope happens to be. CVE-2025-30066 (the March 2025 `tj-actions/changed-files` supply-chain compromise) is the practical motivation - a tampered third-party action can exfiltrate `GITHUB_TOKEN` via workflow logs, and the blast radius matches the issued scope. CodeQL workflows are particularly attractive targets since they routinely run with broader implicit access. Declaring the minimum here caps that runtime authority and is what OpenSSF Scorecard's Token-Permissions check looks for.

YAML validated locally with `yaml.safe_load`.
