### PR TITLE
Bootstrap agent-ready project context under .claude/

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,21 @@
+# Architecture rules
+
+The service is an **ingest → accumulate → store → query** pipeline. Respect package boundaries:
+
+- `engine/` — ingestion (Line/Pickle/Netty, Kinesis), relay routing, input queues, point processors, HTTP servlets.
+- `accumulator/` — aggregator-style rollups; `AccumulatorImpl` slots points and applies `MetricAggregationRule`s.
+- `db/` — storage facade `TimeSeriesStoreImpl`.
+  - `db/index/` — name → numeric id, glob queries (`MetricIndexImpl`, `IndexStoreRocksDB`, `QueryUtils`).
+  - `db/points/` — per-resolution RocksDB column families and archive readers/writers.
+  - `db/model/` — domain types (`Metric`, `Series`, `RetentionPolicy`, `DataPointStore`).
+- `admin/` — REST admin endpoints rooted at `/_dw/rest/carbonj/...`.
+
+## Invariants — do not break
+
+- **Retention dbName values** (`60s24h`, `5m7d`, `30m2y`) are part of the public surface. Admin APIs and external scripts depend on them.
+- The 60s / 5m / 30m archive layout is the storage contract — schema changes here need migration plans.
+- Kinesis tunables live in `cfgKinesis.java`; checkpointing is `FileCheckPointMgr` or `DynamoDbCheckPointMgr`.
+- Runtime configuration order of authority: env vars → `application.yml` profile → `service.args` → defaults.
+- Python/shell helpers in `carbonj.service/src/main/docker/files/` are baked into the image. Update them in lockstep with related Java changes.
+
+When wiring new beans/tunables, look at the matching `cfg*` class first instead of inventing a new injection site.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,7 @@
+# Security rules
+
+- Never read or commit secrets. Files matching `**/*.env`, `**/secrets/**`, `**/credentials*`, `**/*.pem`, `**/*.key`, `**/.aws/**` must not be opened, edited, or printed.
+- AWS access in tests uses Testcontainers/LocalStack — do not introduce real AWS credentials in test fixtures.
+- Do not log raw metric payloads or customer namespace names at INFO; use DEBUG and gate behind a flag.
+- Releases run from `master` only (`release.git.requireBranch = 'master'`). Do not push tags or run the release plugin from feature branches.
+- The Docker image login uses a GitHub Actions secret (`SALESFORCE_DOCKER_HUB_SECRET`); never echo or hardcode it locally.

--- a/.claude/rules/style.md
+++ b/.claude/rules/style.md
@@ -1,0 +1,11 @@
+# Code style rules
+
+- **Java 17** source/target across all subprojects. Do not use language features beyond JDK 17.
+- BSD-3-Clause license header (from `LICENSE-HEADER-JAVA`) is required on every Java file and every file in `carbonj.service/src/main/docker/files/`. The `licenseMain` task runs as part of `build` and **fails the build on missing headers**.
+  - To auto-add/repair: `./gradlew licenseFormat`
+  - To check: `./gradlew licenseMain` (or just `./gradlew build`)
+- Spring `@Configuration` classes follow the `cfg*` naming convention (e.g. `cfgKinesis`, `cfgCarbonJ`). Add new config classes under `engine/` or the relevant package using the same pattern.
+- Use `Slf4jLogger` / `org.slf4j.Logger` for logging — no `System.out.println`.
+- Prefer constructor injection over field injection for new Spring beans.
+- Versions for third-party deps live in root `gradle.properties`; do **not** hard-code versions in `build.gradle` files.
+- Do not introduce new build tools or plugins without a clear reason; prefer existing tooling.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,13 @@
+# Testing rules
+
+- Tests use **JUnit 5** (`useJUnitPlatform()`); do not introduce JUnit 4 styles.
+- Run the service module's tests with `./gradlew :carbonj.service:test`.
+- Run a single test class/method:
+  `./gradlew :carbonj.service:test --tests com.demandware.carbonj.service.SomeTest.someMethod`
+- Tests run with `--add-opens java.base/java.util=ALL-UNNAMED` and `AWS_REGION=us-east-1` set automatically by the build.
+- **Integration tests need Docker** — they use Testcontainers + LocalStack (Kinesis / DynamoDB). If Docker is unavailable, scope to unit tests with `--tests <FQCN>`.
+- Test resources live in `carbonj.service/src/test/resources/` (e.g. `aggregation-rules-test.conf`, `relay-rules.conf`, `storage-aggregation.conf`). Reuse existing fixtures rather than inventing new config files.
+- After running tests, HTML reports are at `carbonj.service/build/reports/tests/test/index.html` and surefire XML at `carbonj.service/build/test-results/test/`.
+- JaCoCo coverage runs as part of `build`; print a summary with `./gradlew printCoverageReport`.
+- Do **not** mock RocksDB — there are real on-disk fixtures in tests; follow the patterns in `db/` tests.
+- Before declaring a change done, run at minimum `./gradlew :carbonj.service:test` for the touched module.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,70 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./**/*.env)",
+      "Read(./**/*.env.*)",
+      "Read(./**/secrets/**)",
+      "Read(./**/credentials*)",
+      "Read(./**/*.pem)",
+      "Read(./**/*.key)",
+      "Read(./**/.aws/**)",
+      "Read(./**/.ssh/**)",
+      "Bash(rm -rf *)",
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard *)",
+      "Bash(git clean -fdx *)",
+      "Bash(./gradlew release *)",
+      "Bash(./gradlew publish *)",
+      "Bash(docker push *)",
+      "Bash(curl * | sh)",
+      "Bash(curl * | bash)"
+    ],
+    "allow": [
+      "Bash(./gradlew build)",
+      "Bash(./gradlew build *)",
+      "Bash(./gradlew test)",
+      "Bash(./gradlew test *)",
+      "Bash(./gradlew :carbonj.service:test)",
+      "Bash(./gradlew :carbonj.service:test *)",
+      "Bash(./gradlew :carbonj.service:bootJar)",
+      "Bash(./gradlew :carbonj.service:bootJar *)",
+      "Bash(./gradlew :cc-metrics-reporter:test)",
+      "Bash(./gradlew :cc-metrics-reporter:test *)",
+      "Bash(./gradlew licenseMain)",
+      "Bash(./gradlew licenseFormat)",
+      "Bash(./gradlew printCoverageReport)",
+      "Bash(./gradlew tasks)",
+      "Bash(./gradlew tasks *)",
+      "Bash(./gradlew properties)",
+      "Bash(./gradlew dependencies *)",
+      "Bash(./gradlew clean)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
+      "Bash(git log)",
+      "Bash(git log *)",
+      "Bash(git branch)",
+      "Bash(git branch *)",
+      "Bash(git checkout *)",
+      "Bash(git fetch)",
+      "Bash(git fetch *)",
+      "Bash(git pull --ff-only)",
+      "Bash(git stash)",
+      "Bash(git stash *)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'CarbonJ — Spring Boot 3 / JDK 17 / Gradle multi-project. Golden commands:\\n  build:  ./gradlew build\\n  test:   ./gradlew :carbonj.service:test\\n  jar:    ./gradlew :carbonj.service:bootJar\\n  lint:   ./gradlew licenseMain (auto-fix: licenseFormat)\\nSee CLAUDE.md and .claude/rules/ for details.'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: debug
+description: Structured triage workflow for CarbonJ bugs — reproduce, isolate to a pipeline phase (ingest / accumulate / store / query), then write a failing test before patching.
+---
+
+# /debug — CarbonJ bug triage
+
+## 1. Reproduce
+- Capture exact command, profile, and inputs that trigger the bug.
+- If from production logs, note timestamps, metric names, and any `cfgKinesis` / `cfgAccumulator` overrides in effect.
+
+## 2. Localize to a pipeline phase
+CarbonJ is **ingest → accumulate → store → query**. Identify which phase failed:
+
+| Symptom | Likely phase | Where to look |
+|---|---|---|
+| Points dropped at the edge, line-protocol parse errors | ingest | `engine/LineProtocolHandler`, `engine/PickleProtocolHandler`, `netty/`, `InputQueue`, `PointProcessor*` |
+| Kinesis lag, checkpoint stuck, KCL warnings | ingest (Kinesis) | `engine/KinesisConsumer`, `KinesisRecordProcessor`, `cfgKinesis`, `FileCheckPointMgr`, `DynamoDbCheckPointMgr` |
+| Wrong rollup values, missing aggregated series | accumulate | `accumulator/AccumulatorImpl`, `MetricAggregationRule`, `aggregation-rules-test.conf`, `recovery/` |
+| Glob queries return nothing / wrong ids | store/index | `db/index/MetricIndexImpl`, `IndexStoreRocksDB`, `QueryUtils`, `QueryPart` |
+| Data missing in 5m or 30m archive | store/points | `db/points/DataPointArchiveRocksDB`, `IntervalProcessor*`, `StagingFile*` |
+| HTTP 500 / wrong JSON shape | query | `engine/Graphite*Servlet`, `admin/` |
+| Wrong routing between shards | relay | `Relay`, `RelayRouter`, `RelayRules`, `relay-rules.conf`, `blacklist.conf` |
+
+## 3. Read the matching `cfg*` class
+The bean wiring for the phase is in the corresponding `@Configuration` class. Tunables almost always live there, not at the use site.
+
+## 4. Write a failing test
+Add a JUnit 5 test in the matching package under `carbonj.service/src/test/java/...`. Reuse fixtures from `carbonj.service/src/test/resources/` (e.g. `aggregation-rules-test.conf`).
+
+Run scoped:
+```bash
+./gradlew :carbonj.service:test --tests <FQCN>.<method> --info
+```
+
+## 5. Patch and verify
+- Make the smallest change that turns the test green.
+- Re-run the full module suite: `./gradlew :carbonj.service:test`.
+- Check license headers if you added new files: `./gradlew licenseMain`.
+
+## Common gotchas
+- Do not change the dbName values `60s24h`, `5m7d`, `30m2y` — admin APIs depend on them.
+- LocalStack/Testcontainers tests need Docker; if the bug is in `kinesis/`, you need it running locally.
+- Releases must run from `master`; debug commits should land on a feature branch.

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lint
+description: Verify and auto-fix the BSD-3-Clause license headers that the build enforces. CarbonJ has no checkstyle/spotless — license headers are the only enforced static check.
+---
+
+# /lint — License header check (the only enforced static check)
+
+## Verify
+```bash
+./gradlew licenseMain
+```
+Runs as part of `./gradlew build`. Fails if any Java file or `src/main/docker/files/*` is missing the BSD-3-Clause header from `LICENSE-HEADER-JAVA`.
+
+## Auto-fix
+```bash
+./gradlew licenseFormat
+```
+Inserts/repairs headers in place. Re-run `./gradlew licenseMain` to confirm.
+
+## Success
+- `licenseMain` exits 0 with no `Missing header` lines.
+
+## On failure
+- The error lists the offending files. Run `./gradlew licenseFormat`, then `git diff` to verify the change is just header insertion before committing.
+
+## Note
+There is no project-wide checkstyle, spotless, or formatter task. Java compilation itself surfaces the only other "static" feedback.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: review
+description: Self-review checklist for a CarbonJ change before opening or merging a PR. Aligns with what CI enforces.
+---
+
+# /review — CarbonJ self-review checklist
+
+Run through this before pushing or requesting review.
+
+## 1. Build & tests pass
+```bash
+./gradlew build printCoverageReport
+```
+This mirrors CI (`.github/workflows/gradle.yml`). If this is green, CI will be green.
+
+For a faster loop while iterating:
+```bash
+./gradlew :carbonj.service:test
+```
+
+## 2. License headers
+- Any new `.java` file under either module?
+- Any new file under `carbonj.service/src/main/docker/files/`?
+
+If yes:
+```bash
+./gradlew licenseFormat && ./gradlew licenseMain
+```
+
+## 3. Storage compatibility
+- Did you touch anything in `db/`?
+  - dbName values (`60s24h`, `5m7d`, `30m2y`) **unchanged**?
+  - RocksDB column-family names unchanged?
+  - Any on-disk format change → flag in PR description; needs a migration plan.
+
+## 4. Configuration surface
+- New tunable? Added to the matching `cfg*` class **and** documented in `application.yml` (with a default that matches existing behavior)?
+- Touched `service.args`, `relay-rules.conf`, `blacklist.conf`, or other files in `src/main/docker/files/`? Confirm Dockerfile still picks them up.
+
+## 5. Public APIs
+- HTTP endpoint signatures under `/_dw/rest/carbonj/...` or Graphite servlets unchanged? If changed, update `admin-api.md` / `delete-api.md`.
+
+## 6. Ops scripts
+- Did the Java change rename a metric, env var, or path that a script in `src/main/docker/files/*.py` / `*.sh` reads? Update the script in the same PR.
+
+## 7. Commit hygiene
+- Branch is **not** `master` (releases run from `master` only).
+- Commits compile individually if you bisected.
+- PR description lists: behavior change, risk area, rollout/rollback notes if it touches storage or ingestion.
+
+## 8. Final
+```bash
+git status
+git diff --stat origin/master...HEAD
+```
+Nothing unintended staged.
+
+## Success
+- CI is green.
+- All checklist items above either apply (and were addressed) or are explicitly N/A.

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: run
+description: Build the bootJar and start CarbonJ locally on the default `dev` profile.
+---
+
+# /run — Start CarbonJ locally
+
+## 1. Build the runnable jar
+```bash
+./gradlew :carbonj.service:bootJar
+```
+Output: `carbonj.service/build/libs/carbonj.service-<version>.jar`
+
+## 2. Run
+```bash
+java --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+     -jar carbonj.service/build/libs/carbonj.service-*.jar
+```
+
+Defaults: HTTP on `:2001`, Spring profile `dev`, store disabled.
+
+## Override profile / config
+```bash
+java -Dspring.profiles.active=dev \
+     --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+     -jar carbonj.service/build/libs/carbonj.service-*.jar
+```
+
+Runtime config is at `carbonj.service/src/main/resources/application.yml` (profiles: `dev`, `test`, `prod`). For container-style overrides see `carbonj.service/src/main/docker/files/service.args`.
+
+## Success
+- Banner prints, log shows `Started CarbonJServiceMain in N seconds`.
+- `curl http://localhost:2001/_dw/healthcheck` returns 200 (or your project's healthcheck path).
+
+## On failure
+- `Address already in use :2001` → stop the prior instance or change the port.
+- `ClassNotFoundException` → re-run `./gradlew clean :carbonj.service:bootJar`.
+- Kinesis / store errors on `dev` profile → confirm the profile actually disables those (look at `application.yml`); start with `-Dspring.profiles.active=dev` explicitly.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: test
+description: Run CarbonJ tests. Defaults to the service module's full unit+integration suite. Pass an FQCN (e.g. `com.demandware.carbonj.service.db.points.SomeTest`) or pattern to scope.
+---
+
+# /test — Run CarbonJ tests
+
+## Default (full service suite)
+```bash
+./gradlew :carbonj.service:test
+```
+
+## Targeted run
+If the user passed an argument (FQCN or pattern):
+```bash
+./gradlew :carbonj.service:test --tests "<arg>"
+```
+
+## Both modules
+```bash
+./gradlew test
+```
+
+## Prerequisites
+- JDK 17 on PATH (`java -version`).
+- **Docker daemon running** if any test under `kinesis/`, `recovery/`, or anything using `@Testcontainers` is in scope (LocalStack-based). If Docker is not available, scope to unit-only with `--tests`.
+
+## Success
+- Gradle exits 0.
+- Final line shows the test summary; per-test report at `carbonj.service/build/reports/tests/test/index.html`.
+
+## On failure
+1. Inspect the surefire XML at `carbonj.service/build/test-results/test/TEST-*.xml`.
+2. Re-run a single failing test: `./gradlew :carbonj.service:test --tests <FQCN>.<method> --info`.
+3. If the failure mentions Docker / Testcontainers / LocalStack, confirm `docker ps` works, then retry.
+4. If the failure mentions license headers, run `./gradlew licenseFormat` and rebuild.


### PR DESCRIPTION
Add modular rules (testing, style, architecture, security), shared project settings with safe permissions and a SessionStart hook, and operational skills (test, lint, run, debug, review) so agents have a consistent starting point in this repo.