### PR TITLE
Align test logback config with prod to prevent secret leaks

### DIFF
--- a/carbonj.service/src/test/resources/logback-spring.xml
+++ b/carbonj.service/src/test/resources/logback-spring.xml
@@ -38,7 +38,7 @@
             <maxHistory>5</maxHistory>
         </rollingPolicy>
     </appender>
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="ROLLING-FILE"/>
         <appender-ref ref="CONSOLE"/>
     </root>
@@ -48,7 +48,7 @@
 <!--
 separate kinesis log file
 -->
-    <logger name="com.amazonaws.services.kinesis" level="DEBUG" additivity="false">
+    <logger name="software.amazon.kinesis" level="DEBUG" additivity="false">
         <appender-ref ref="KINESIS-FILE"/>
     </logger>
     <logger name="com.demandware" level="INFO" additivity="false">


### PR DESCRIPTION
Test root logger was DEBUG, causing AWS SDK and other third-party loggers to emit request-level details into CI build logs. Match prod (root INFO) and update the stale Kinesis logger name from the deprecated SDK v1 package to the KCL v3 package.